### PR TITLE
Bug fix in NodeHeap

### DIFF
--- a/kademlia/node.py
+++ b/kademlia/node.py
@@ -94,8 +94,9 @@ class NodeHeap(object):
             nodes = [nodes]
 
         for node in nodes:
-            distance = self.node.distanceTo(node)
-            heapq.heappush(self.heap, (distance, node))
+	    if node.id not in [n.id for n in self]:
+                distance = self.node.distanceTo(node)
+                heapq.heappush(self.heap, (distance, node))
 
     def __len__(self):
         return min(len(self.heap), self.maxsize)

--- a/kademlia/node.py
+++ b/kademlia/node.py
@@ -94,7 +94,7 @@ class NodeHeap(object):
             nodes = [nodes]
 
         for node in nodes:
-	    if node.id not in [n.id for n in self]:
+	    if node not in self:
                 distance = self.node.distanceTo(node)
                 heapq.heappush(self.heap, (distance, node))
 
@@ -104,6 +104,12 @@ class NodeHeap(object):
     def __iter__(self):
         nodes = heapq.nsmallest(self.maxsize, self.heap)
         return iter(map(itemgetter(1), nodes))
+
+    def __contains__(self, node):
+        for distance, n in self.heap:
+            if node.id == n.id:
+                return True
+        return False	
 
     def getUncontacted(self):
         return [n for n in self if n.id not in self.contacted]


### PR DESCRIPTION
When running with a large number of nodes it fails to send the store request
to the k closest nodes and instead ends up sending multiple store requests to
the same 4 or 5 nodes.

It appears the cause is a bug in NodeHeap which allows the same node to be
pushed onto the heap multiple times bumping out other legimate nodes.

This pull request just adds some logic to make sure the node isn't already
in the heap before pushing.