### PR TITLE
Verified unpredictable host node ids

### DIFF
--- a/kademlia/crawling.py
+++ b/kademlia/crawling.py
@@ -114,7 +114,7 @@ class ValueSpiderCrawl(SpiderCrawl):
 
         peerToSaveTo = self.nearestWithoutValue.popleft()
         if peerToSaveTo is not None:
-            d = self.protocol.callStore(peerToSaveTo, self.node.id, value)
+            d = self.protocol.callStore(peerToSaveTo, self.node.id[0], value)
             return d.addCallback(lambda _: value)
         return value
 
@@ -174,4 +174,12 @@ class RPCFindResponse(object):
         be set.
         """
         nodelist = self.response[1] or []
-        return [Node(*nodeple) for nodeple in nodelist]
+        out = []
+        for nodeple in nodelist:
+            try:
+                node = HostNode(*nodeple)
+            except NodeValidationError as e:
+                #  TODO log
+                continue
+            out.append(node)
+        return out

--- a/kademlia/crawling.py
+++ b/kademlia/crawling.py
@@ -177,7 +177,7 @@ class RPCFindResponse(object):
         out = []
         for nodeple in nodelist:
             try:
-                node = HostNode(*nodeple)
+                node = ValidatedNode(*nodeple)
             except NodeValidationError as e:
                 #  TODO log
                 continue

--- a/kademlia/network.py
+++ b/kademlia/network.py
@@ -37,10 +37,7 @@ class Server(object):
         self.log = Logger(system=self)
         self.storage = storage or ForgetfulStorage()
         if id:
-            try:
-                self.node = HostNode(id)
-            except NodeVerificationError as e:
-                self.log.warning(e)
+            self.node = HostNode(id)
         else:
             id_src = os.urandom(20)
             id_digest = digest(id_src)

--- a/kademlia/network.py
+++ b/kademlia/network.py
@@ -1,7 +1,7 @@
 """
 Package for interacting on the network at a high level.
 """
-import random
+import os
 import pickle
 
 from twisted.internet.task import LoopingCall
@@ -11,7 +11,7 @@ from kademlia.log import Logger
 from kademlia.protocol import KademliaProtocol
 from kademlia.utils import deferredDict, digest
 from kademlia.storage import ForgetfulStorage
-from kademlia.node import Node
+from kademlia.node import HostNode, ValueNode, NodeVerificationError
 from kademlia.crawling import ValueSpiderCrawl
 from kademlia.crawling import NodeSpiderCrawl
 
@@ -36,7 +36,15 @@ class Server(object):
         self.alpha = alpha
         self.log = Logger(system=self)
         self.storage = storage or ForgetfulStorage()
-        self.node = Node(id or digest(random.getrandbits(255)))
+        if id:
+            try:
+                self.node = HostNode(id)
+            except NodeVerificationError as e:
+                self.log.warning(e)
+        else:
+            id_src = os.urandom(20)
+            id_digest = digest(id_src)
+            self.node = HostNode((id_digest, id_src))
         self.protocol = KademliaProtocol(self.node, self.storage, ksize)
         self.refreshLoop = LoopingCall(self.refreshTable).start(3600)
 
@@ -57,7 +65,7 @@ class Server(object):
         """
         ds = []
         for id in self.protocol.getRefreshIDs():
-            node = Node(id)
+            node = ValueNode((id, None))
             nearest = self.protocol.router.findNeighbors(node, self.alpha)
             spider = NodeSpiderCrawl(self.protocol, node, nearest)
             ds.append(spider.find())
@@ -100,7 +108,12 @@ class Server(object):
             nodes = []
             for addr, result in results.items():
                 if result[0]:
-                    nodes.append(Node(result[1], addr[0], addr[1]))
+                    try:
+                        node = HostNode(tuple(result[1]), addr[0], addr[1])
+                    except NodeVerificationError as e:
+                        self.log.warning(e)
+                        continue
+                    nodes.append(node)
             spider = NodeSpiderCrawl(self.protocol, self.node, nodes, self.ksize, self.alpha)
             return spider.find()
 
@@ -137,7 +150,7 @@ class Server(object):
         # if this node has it, return it
         if self.storage.get(dkey) is not None:
             return defer.succeed(self.storage.get(dkey))
-        node = Node(dkey)
+        node = ValueNode((dkey, None))
         nearest = self.protocol.router.findNeighbors(node)
         if len(nearest) == 0:
             self.log.warning("There are no known neighbors to get key %s" % key)
@@ -151,7 +164,7 @@ class Server(object):
         """
         self.log.debug("setting '%s' = '%s' on network" % (key, value))
         dkey = digest(key)
-        node = Node(dkey)
+        node = ValueNode((dkey, None))
 
         def store(nodes):
             self.log.info("setting '%s' on %s" % (key, map(str, nodes)))

--- a/kademlia/node.py
+++ b/kademlia/node.py
@@ -10,7 +10,7 @@ def format_nodeid(id):
     )
 
 
-class NodeVerificationError(RuntimeError):
+class NodeValidationError(RuntimeError):
     pass
 
 
@@ -45,15 +45,15 @@ class Node:
         return "%s:%s" % (self.ip, str(self.port))
 
 
-class ValueNode(Node):
+class UnvalidatedNode(Node):
     def __init__(self, id, ip=None, port=None):
         Node.__init__(self, id, ip, port, True)
 
 
-class HostNode(Node):
+class ValidatedNode(Node):
     def __init__(self, id, ip=None, port=None):
         if id[0] != digest(id[1]):
-            raise NodeVerificationError(
+            raise NodeValidationError(
                 "Encountered host node with invalid id: {} at {}:{}".format(format_nodeid(id), ip, port) if ip and port else
                 "Local host node id is invalid: {}".format(format_nodeid(id)))
         Node.__init__(self, id, ip, port, True)

--- a/kademlia/node.py
+++ b/kademlia/node.py
@@ -1,13 +1,27 @@
 from operator import itemgetter
 import heapq
+from kademlia.utils import digest
+
+
+def format_nodeid(id):
+    return (
+        long(id[0].encode('hex'), 16),
+        long(id[1].encode('hex'), 16) if id[1] is not None else None
+    )
+
+
+class NodeVerificationError(RuntimeError):
+    pass
 
 
 class Node:
-    def __init__(self, id, ip=None, port=None):
+    def __init__(self, id, ip=None, port=None, derived=False):
+        if not derived:
+            raise AssertionError('Node base class instantiated.')
         self.id = id
         self.ip = ip
         self.port = port
-        self.long_id = long(id.encode('hex'), 16)
+        self.long_id = long(id[0].encode('hex'), 16)
 
     def sameHomeAs(self, node):
         return self.ip == node.ip and self.port == node.port
@@ -29,6 +43,20 @@ class Node:
 
     def __str__(self):
         return "%s:%s" % (self.ip, str(self.port))
+
+
+class ValueNode(Node):
+    def __init__(self, id, ip=None, port=None):
+        Node.__init__(self, id, ip, port, True)
+
+
+class HostNode(Node):
+    def __init__(self, id, ip=None, port=None):
+        if id[0] != digest(id[1]):
+            raise NodeVerificationError(
+                "Encountered host node with invalid id: {} at {}:{}".format(format_nodeid(id), ip, port) if ip and port else
+                "Local host node id is invalid: {}".format(format_nodeid(id)))
+        Node.__init__(self, id, ip, port, True)
 
 
 class NodeHeap(object):

--- a/kademlia/tests/utils.py
+++ b/kademlia/tests/utils.py
@@ -1,27 +1,28 @@
 """
 Utility functions for tests.
 """
-import random
+import os
 import hashlib
 from struct import pack
 
-from kademlia.node import Node
+from kademlia.node import UnvalidatedNode, ValidatedNode
 from kademlia.routing import RoutingTable
 
 
-def mknode(id=None, ip=None, port=None, intid=None):
+def mknode(id=None, ip=None, port=None, intid=None, intpreid=None):
     """
     Make a node.  Created a random id if not specified.
     """
     if intid is not None:
-        id = pack('>l', intid)
-    id = id or hashlib.sha1(str(random.getrandbits(255))).digest()
-    return Node(id, ip, port)
+        id = (pack('>l', intid), None)
+    preid = pack('>l', intpreid) if intpreid else os.urandom(20)
+    id = id or (hashlib.sha1(preid).digest(), preid)
+    return UnvalidatedNode(id, ip, port)
 
 
 class FakeProtocol(object):
     def __init__(self, sourceID, ksize=20):
-        self.router = RoutingTable(self, ksize, Node(sourceID))
+        self.router = RoutingTable(self, ksize, ValidatedNode(sourceID))
         self.storage = {}
         self.sourceID = sourceID
 
@@ -35,25 +36,25 @@ class FakeProtocol(object):
         return ids
 
     def rpc_ping(self, sender, nodeid):
-        source = Node(nodeid, sender[0], sender[1])
+        source = ValidatedNode(nodeid, sender[0], sender[1])
         self.router.addContact(source)
         return self.sourceID
 
     def rpc_store(self, sender, nodeid, key, value):
-        source = Node(nodeid, sender[0], sender[1])
+        source = ValidatedNode(nodeid, sender[0], sender[1])
         self.router.addContact(source)
         self.log.debug("got a store request from %s, storing value" % str(sender))
         self.storage[key] = value
 
     def rpc_find_node(self, sender, nodeid, key):
         self.log.info("finding neighbors of %i in local table" % long(nodeid.encode('hex'), 16))
-        source = Node(nodeid, sender[0], sender[1])
+        source = ValidatedNode(nodeid, sender[0], sender[1])
         self.router.addContact(source)
-        node = Node(key)
+        node = UnvalidatedNode((key, None))
         return map(tuple, self.router.findNeighbors(node, exclude=source))
 
     def rpc_find_value(self, sender, nodeid, key):
-        source = Node(nodeid, sender[0], sender[1])
+        source = ValidatedNode(nodeid, sender[0], sender[1])
         self.router.addContact(source)
         value = self.storage.get(key, None)
         if value is None:


### PR DESCRIPTION
Stock Kademlia is vulnerable to eclipse attacks and node insertion attacks (also sometimes called eclipse attacks) where a bad actor crafts a specific node id.

A couple papers suggest using a key system and in addition using the public keys as a basis for non-craftable node ids, but I think this is simpler (original research, layman, I could very well have no idea what I'm doing).

The node id is defined as `(hash(random), random)`.
When a new host is encountered, check that `id[0] == hash(id[1])`, ignore them if it isn't valid.
Given hash `x`, it's difficult to come up with `r` where `hash(r) == x`.  This should prevent crafting an id to intentionally neighbor a target host or to become the ideal host for a particular key.