### PR TITLE
Verifiably unpredictable ids (revised)

### DIFF
--- a/kademlia/crawling.py
+++ b/kademlia/crawling.py
@@ -2,7 +2,7 @@ from collections import Counter
 
 from kademlia.log import Logger
 from kademlia.utils import deferredDict
-from kademlia.node import Node, NodeHeap
+from kademlia.node import UnvalidatedNode, NodeHeap
 
 
 class SpiderCrawl(object):
@@ -174,4 +174,4 @@ class RPCFindResponse(object):
         be set.
         """
         nodelist = self.response[1] or []
-        return [Node(*nodeple) for nodeple in nodelist]
+        return [UnvalidatedNode(tuple(nodeple[0]), nodeple[1], nodeple[2]) for nodeple in nodelist]

--- a/kademlia/network.py
+++ b/kademlia/network.py
@@ -41,14 +41,7 @@ class Server(object):
             self.node = OwnNode.restore(seed)
         else:
             self.node = OwnNode.new()
-        self.log.debug(
-            'Own node: {}'.format(
-                json.dumps({
-                    'id': self.node.id.encode('hex'),
-                    'preid': self.node.preid.encode('hex'),
-                }, indent=4),
-            )
-        )
+        self.log.debug('Own node: {}'.format(self.node))
         self.protocol = KademliaProtocol(self.node, self.storage, ksize)
         self.refreshLoop = LoopingCall(self.refreshTable).start(3600)
 
@@ -112,7 +105,7 @@ class Server(object):
             nodes = []
             for addr, result in results.items():
                 if result[0]:
-                    nodes.append(UnvalidatedNode(result[1], addr[0], addr[1]))
+                    nodes.append(UnvalidatedNode(tuple(result[1]), addr[0], addr[1]))
             spider = NodeSpiderCrawl(self.protocol, self.node, nodes, self.ksize, self.alpha)
             return spider.find()
 

--- a/kademlia/node.py
+++ b/kademlia/node.py
@@ -10,7 +10,7 @@ from kademlia.utils import digest
 
 
 def format_nodeid(nodeid):
-    return '{:.6}~, {:.6}~'.format(nodeid[0].encode('hex'), nodeid[1].encode('hex'))
+    return '({:.6}~, {:.6}~)'.format(nodeid[0].encode('hex'), nodeid[1].encode('hex') if nodeid[1] else 'None')
 
 
 class NodeValidationError(RuntimeError):
@@ -44,10 +44,10 @@ class Node:
         return iter([self.id, self.ip, self.port])
 
     def __repr__(self):
-        return repr([format_nodeid(self.id), self.ip, self.port])
+        return repr([self.id, self.ip, self.port])
 
     def __str__(self):
-        return "%s:%s" % (self.ip, str(self.port))
+        return '{} @ {}:{}'.format(format_nodeid(self.id), self.ip, self.port)
 
 
 class UnvalidatedNode(Node):

--- a/kademlia/protocol.py
+++ b/kademlia/protocol.py
@@ -80,7 +80,7 @@ class KademliaProtocol(RPCProtocol):
 
     def rpc_find_value(self, sender, nodeid, key):
         self._addContact(nodeid, sender)
-        value = self.storage.get(key, None)
+        value = self.storage.get(key[0], None)
         if value is None:
             return self.rpc_find_node(sender, nodeid, key)
         return { 'value': value }

--- a/kademlia/protocol.py
+++ b/kademlia/protocol.py
@@ -44,6 +44,7 @@ class KademliaProtocol(RPCProtocol):
             self.welcomeNewNode(node)
             return True
         if not self.router.isNewNode(node):
+            self.log.debug('Freshening {}'.format(node))
             self.router.addContact(node)
             return defer.succeed(True)
         else:
@@ -141,13 +142,7 @@ class KademliaProtocol(RPCProtocol):
         """
         if result[0]:
             self.log.info("got response from %s, adding to router" % node)
-            d = self._addContact(node.id, (node.ip, node.port))
-            def transfer(result):
-                if not result:
-                    return
-                if self.router.isNewNode(node):
-                    self.transferKeyValues(node)
-            d.addCallback(transfer)
+            self._addContact(node.id, (node.ip, node.port))
         else:
             self.log.debug("no response from %s, removing from router" % node)
             self.router.removeContact(node)

--- a/kademlia/routing.py
+++ b/kademlia/routing.py
@@ -31,13 +31,14 @@ class KBucket(object):
 
     def removeNode(self, node):
         if node.id not in self.nodes:
-            return
+            return False
 
         # delete node, and see if we can add a replacement
         del self.nodes[node.id]
         if len(self.replacementNodes) > 0:
             newnode = self.replacementNodes.pop()
             self.nodes[newnode.id] = newnode
+        return True
 
     def hasInRange(self, node):
         return self.range[0] <= node.long_id <= self.range[1]
@@ -138,7 +139,7 @@ class RoutingTable(object):
 
     def removeContact(self, node):
         index = self.getBucketFor(node)
-        self.buckets[index].removeNode(node)
+        return self.buckets[index].removeNode(node)
 
     def isNewNode(self, node):
         index = self.getBucketFor(node)

--- a/kademlia/tests/test_node.py
+++ b/kademlia/tests/test_node.py
@@ -1,26 +1,54 @@
 import random
 import hashlib
+from struct import pack
 
 from twisted.trial import unittest
 
-from kademlia.node import Node, NodeHeap
+from kademlia.node import (
+    UnvalidatedNode, ValidatedNode, OwnNode, NodeHeap, NodeValidationError
+)
 from kademlia.tests.utils import mknode
 
 
 class NodeTest(unittest.TestCase):
+    def test_idSize(self):
+        self.assertEqual(len(OwnNode.new().id[0]), 20)
+
     def test_longID(self):
-        rid = hashlib.sha1(str(random.getrandbits(255))).digest()
-        n = Node(rid)
-        self.assertEqual(n.long_id, long(rid.encode('hex'), 16))
+        n = mknode()
+        self.assertEqual(n.long_id, long(n.id[0].encode('hex'), 16))
 
     def test_distanceCalculation(self):
-        ridone = hashlib.sha1(str(random.getrandbits(255)))
-        ridtwo = hashlib.sha1(str(random.getrandbits(255)))
-
-        shouldbe = long(ridone.hexdigest(), 16) ^ long(ridtwo.hexdigest(), 16)
-        none = Node(ridone.digest())
-        ntwo = Node(ridtwo.digest())
+        none = mknode()
+        ntwo = mknode()
+        shouldbe = long(none.id[0].encode('hex'), 16) ^ long(ntwo.id[0].encode('hex'), 16)
         self.assertEqual(none.distanceTo(ntwo), shouldbe)
+
+    def test_idValidation(self):
+        node = OwnNode.restore(pack('>llllllll', 0, 0, 0 ,0, 0, 0, 0, 15))
+        node2 = ValidatedNode(node.id)
+
+        # valid
+        challenge = pack('>l', 244)
+        response = node.completeChallenge(challenge)
+        node2.validate(challenge, response)
+
+        # invalid signature raises
+        challenge = pack('>l', 244)
+        response = pack('>l', 11)
+        self.assertRaises(
+            NodeValidationError, 
+            lambda: node2.validate(challenge, response))
+
+        # invalid digest raises
+        challenge = pack('>l', 244)
+        response = node.completeChallenge(challenge)
+        temp = list(node2.id[0])
+        temp[0] = 'a'
+        node2.id = (''.join(temp), node2.id[1])
+        self.assertRaises(
+            NodeValidationError, 
+            lambda: node2.validate(challenge, response))
 
 
 class NodeHeapTest(unittest.TestCase):

--- a/kademlia/tests/test_routing.py
+++ b/kademlia/tests/test_routing.py
@@ -1,7 +1,8 @@
 from twisted.trial import unittest
 
+from kademlia.node import OwnNode
 from kademlia.routing import KBucket
-from kademlia.tests.utils import mknode, FakeProtocol
+from kademlia.tests.utils import mknode, mkValidatedNode, FakeProtocol
 
 
 class KBucketTest(unittest.TestCase):
@@ -41,11 +42,12 @@ class KBucketTest(unittest.TestCase):
 
 class RoutingTableTest(unittest.TestCase):
     def setUp(self):
-        self.id = mknode().id
-        self.protocol = FakeProtocol(self.id)
+        node = OwnNode.new()
+        self.id = node.id
+        self.protocol = FakeProtocol(node)
         self.router = self.protocol.router
 
     def test_addContact(self):
-        self.router.addContact(mknode())
+        self.router.addContact(mkValidatedNode())
         self.assertTrue(len(self.router.buckets), 1)
         self.assertTrue(len(self.router.buckets[0].nodes), 1)

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,6 @@ setup(
     license="MIT",
     url="http://github.com/bmuller/kademlia",
     packages=find_packages(),
-    requires=["twisted", "rpcudp"],
-    install_requires=['twisted>=14.0', "rpcudp>=1.0"]
+    requires=["twisted", "rpcudp", "PyNaCl"],
+    install_requires=['twisted>=14.0', "rpcudp>=1.0", "PyNaCl>=0.3.0"]
 )


### PR DESCRIPTION
To continue our conversation from the previous ticket, 

I'd be interested in seeing what some other projects are doing.  In my project, I sign the values and include a hash of the signing key's fingerprint in the key.

However, without changes at the protocol level it's still possible for malicious entities to intercept traffic.  If an application signs and validates values then a hostile node can't forge data, but it can deny the existence of data which is enough to censor the network. 

This patch changes node ID generation and adding to the routing table.

Each node creates a secret value (the seed).  From that, it creates a private signing key and a public verification key.  The node's ID is (hash of the verification key, the verification key).

When the local node encounters a new remote node, it sends a challenge message (random) to the new node.  The new node signs the challenge and sends the signature.  The local node validates the signature before adding the node to its routing table. 

This serves two functions.  As with the previous patch, because the ID value used for routing is a hash, a malicious entity cannot choose it freely, say, to match the key of a known value.  Secondly, completing the challenge to new nodes requires knowledge of the secret key, so a malicious entity couldn't craft a node to impersonate another known node. 

This is a significant departure from the original paper so I'd understand if it's not the sort of thing you want to include here.  I think censorship is a concern for many use cases though, so it may be of practical interest.

And, as with the previous patch, I'm not a security expert so please take this with a grain of salt. 
