### PR TITLE
Fix unicode issue with printable characters in log

### DIFF
--- a/kademlia/network.py
+++ b/kademlia/network.py
@@ -9,7 +9,7 @@ from twisted.internet import defer, reactor, task
 
 from kademlia.log import Logger
 from kademlia.protocol import KademliaProtocol
-from kademlia.utils import deferredDict, digest
+from kademlia.utils import deferredDict, digest, safe_log_var
 from kademlia.storage import ForgetfulStorage
 from kademlia.node import Node
 from kademlia.crawling import ValueSpiderCrawl
@@ -149,12 +149,14 @@ class Server(object):
         """
         Set the given key to the given value in the network.
         """
-        self.log.debug("setting '%s' = '%s' on network" % (key, value))
+        safe_key = safe_log_var(key)
+        safe_value = safe_log_var(value)
+        self.log.debug("setting '%s' = '%s' on network" % (safe_key, safe_value))
         dkey = digest(key)
         node = Node(dkey)
 
         def store(nodes):
-            self.log.info("setting '%s' on %s" % (key, map(str, nodes)))
+            self.log.info("setting '%s' on %s" % (safe_key, map(str, nodes)))
             # if this node is close too, then store here as well
             if self.node.distanceTo(node) < max([n.distanceTo(node) for n in nodes]):
                 self.storage[dkey] = value

--- a/kademlia/utils.py
+++ b/kademlia/utils.py
@@ -3,10 +3,36 @@ General catchall for functions that don't make sense as methods.
 """
 import hashlib
 import operator
+import sys
+import binascii
 
 from twisted.internet import defer
 
 
+# Converts unprintable strings to printable hex (if needed.)
+def safe_log_var(v):
+    try:
+        v.encode("ascii")
+        return v.decode("utf-8") + u" (ascii)"
+    except UnicodeEncodeError:
+        # To a byte string.
+        as_bytes = b""
+        if sys.version_info >= (3,0,0):
+            codes = []
+            for ch in v:
+                codes.append(ord(ch))
+
+            if len(codes):
+                as_bytes = bytes(codes)
+        else:
+            for ch in v:
+                as_bytes += chr(ord(ch))
+
+        return binascii.hexlify(as_bytes).decode("utf-8") + u" (hex)"
+    except UnicodeDecodeError:
+        return binascii.hexlify(v).decode("utf-8") + u" (hex)"
+
+        
 def digest(s):
     if not isinstance(s, str):
         s = str(s)


### PR DESCRIPTION
The current code in network.py output the key name and the value to the log on store requests which can garble and crash the terminal on certain character sequences.

My fix is to only write ASCII characters to the log with non-ascii characters encoded as hex (and indicated as such.)
