### PR TITLE
Provide ipv6 address support

### DIFF
--- a/kademlia/network.py
+++ b/kademlia/network.py
@@ -40,7 +40,7 @@ class Server(object):
         self.protocol = KademliaProtocol(self.node, self.storage, ksize)
         self.refreshLoop = LoopingCall(self.refreshTable).start(3600)
 
-    def listen(self, port, interface=None):
+    def listen(self, port, interface=""):
         """
         Start listening on the given port.
 
@@ -50,10 +50,7 @@ class Server(object):
             
         Provide interface="::" to accept ipv6 address
         """
-        if interface==None:
-            return reactor.listenUDP(port, self.protocol)
-        else:
-            return reactor.listenUDP(port, self.protocol, interface)
+        return reactor.listenUDP(port, self.protocol, interface)
 
     def refreshTable(self):
         """

--- a/kademlia/network.py
+++ b/kademlia/network.py
@@ -40,15 +40,20 @@ class Server(object):
         self.protocol = KademliaProtocol(self.node, self.storage, ksize)
         self.refreshLoop = LoopingCall(self.refreshTable).start(3600)
 
-    def listen(self, port):
+    def listen(self, port, interface=None):
         """
         Start listening on the given port.
 
         This is the same as calling::
 
             reactor.listenUDP(port, server.protocol)
+            
+        Provide interface="::" to accept ipv6 address
         """
-        return reactor.listenUDP(port, self.protocol)
+        if interface==None:
+            return reactor.listenUDP(port, self.protocol)
+        else:
+            return reactor.listenUDP(port, self.protocol, interface)
 
     def refreshTable(self):
         """


### PR DESCRIPTION
For class _kademlia.network.Server_:
change 
`listen(port)`
       **to**
`listen(port, interface=None)`
`interface="::"` can be provided to enable **ipv6** support.

This is in accordance with as given in [twisted] (http://twistedmatrix.com/documents/current/core/howto/udp.html#ipv6) documentation