### PR TITLE
Comment change

### DIFF
--- a/kademlia/network.py
+++ b/kademlia/network.py
@@ -48,7 +48,8 @@ class Server(object):
 
             reactor.listenUDP(port, server.protocol)
 
-        Provide interface="::" to accept ipv6 address
+         Args:
+            interface: Supply `'::'` to support ipv6 address. `'::'` is as defined as ipv6 support in `twisted`.
         """
         return reactor.listenUDP(port, self.protocol, interface)
 


### PR DESCRIPTION
Added comments for interface as changed in `listen()` to reflect in [docs](kademlia.readthedocs.org) page.
I am sorry, but didn't realize how the docs page work until I saw my comments spoiling the docs page. Hence fixed comments in `listen` for increased understanding of the interface parameter.