### PR TITLE
some bugs fixed

### DIFF
--- a/kademlia/network.py
+++ b/kademlia/network.py
@@ -73,7 +73,7 @@ class Server(object):
         for id in self.protocol.getRefreshIDs():
             node = Node(id)
             nearest = self.protocol.router.findNeighbors(node, self.alpha)
-            spider = NodeSpiderCrawl(self.protocol, node, nearest, self.ksize, self.alpha, self.node.long_id)
+            spider = NodeSpiderCrawl(self.protocol, node, nearest, self.ksize, self.alpha)
             ds.append(spider.find())
 
         # do our crawling

--- a/kademlia/network.py
+++ b/kademlia/network.py
@@ -73,7 +73,7 @@ class Server(object):
         for id in self.protocol.getRefreshIDs():
             node = Node(id)
             nearest = self.protocol.router.findNeighbors(node, self.alpha)
-            spider = NodeSpiderCrawl(self.protocol, node, nearest)
+            spider = NodeSpiderCrawl(self.protocol, node, nearest, self.ksize, self.alpha, self.node.long_id)
             ds.append(spider.find())
 
         # do our crawling

--- a/kademlia/protocol.py
+++ b/kademlia/protocol.py
@@ -22,7 +22,7 @@ class KademliaProtocol(RPCProtocol):
         """
         ids = []
         for bucket in self.router.getLonelyBuckets():
-            ids.append(random.randint(*bucket.range))
+            ids.append(random.randint(*bucket.range).to_bytes(20, byteorder='big'))
         return ids
 
     def rpc_stun(self, sender):


### PR DESCRIPTION
kademlia/protocol.py KademliaProtocol:getRefreshIDs
 # ids.append(random.randint(*bucket.range))
 # bug fixed: Return a integer id. It should be bytes.
ids.append(random.randint(*bucket.range).to_bytes(20, byteorder='big'))

kademlia/network.py Server:_refresh_table
 # spider = NodeSpiderCrawl(self.protocol, node, nearest)
 # bug fixed: Lack of arguments
spider = NodeSpiderCrawl(self.protocol, node, nearest, self.ksize, self.alpha, self.node.long_id)