### PR TITLE
Make table traverser more accurate.

### DIFF
--- a/kademlia/routing.py
+++ b/kademlia/routing.py
@@ -104,7 +104,7 @@ class TableTraverser(object):
             return next(self)
 
         if len(self.rightBuckets) > 0:
-            self.currentNodes = self.rightBuckets.pop().getNodes()
+            self.currentNodes = self.rightBuckets.pop(0).getNodes()
             self.left = True
             return next(self)
 


### PR DESCRIPTION
Add test case for TableTraverserTest;
Change iteration method pop left from 'rightBuckets' which is nearer.
As discussed in #51  