### PR TITLE
Improve `KBucket.remove_node`

### DIFF
--- a/kademlia/tests/test_routing.py
+++ b/kademlia/tests/test_routing.py
@@ -1,5 +1,6 @@
 import unittest
 
+from random import shuffle
 from kademlia.routing import KBucket, TableTraverser
 from kademlia.tests.utils import mknode, FakeProtocol
 
@@ -30,6 +31,31 @@ class KBucketTest(unittest.TestCase):
             bucket.add_node(node)
         for index, node in enumerate(bucket.get_nodes()):
             self.assertEqual(node, nodes[index])
+
+    def test_remove_node(self):
+        k = 3
+        bucket = KBucket(0, 10, k)
+        nodes = [mknode() for _ in range(10)]
+        for node in nodes:
+            bucket.add_node(node)
+
+        replacement_nodes = bucket.replacement_nodes
+        self.assertEqual(list(bucket.nodes.values()), nodes[:k])
+        self.assertEqual(list(replacement_nodes.values()), nodes[k:])
+
+        bucket.remove_node(nodes.pop())
+        self.assertEqual(list(bucket.nodes.values()), nodes[:k])
+        self.assertEqual(list(replacement_nodes.values()), nodes[k:])
+
+        bucket.remove_node(nodes.pop(0))
+        self.assertEqual(list(bucket.nodes.values()), nodes[:k-1] + nodes[-1:])
+        self.assertEqual(list(replacement_nodes.values()), nodes[k-1:-1])
+
+        shuffle(nodes)
+        for node in nodes:
+            bucket.remove_node(node)
+        self.assertEqual(len(bucket), 0)
+        self.assertEqual(len(replacement_nodes), 0)
 
     def test_in_range(self):
         bucket = KBucket(0, 10, 10)

--- a/kademlia/tests/test_utils.py
+++ b/kademlia/tests/test_utils.py
@@ -1,7 +1,7 @@
 import hashlib
 import unittest
 
-from kademlia.utils import digest, shared_prefix, OrderedSet
+from kademlia.utils import digest, shared_prefix
 
 
 class UtilsTest(unittest.TestCase):
@@ -24,13 +24,3 @@ class UtilsTest(unittest.TestCase):
 
         args = ['hi']
         self.assertEqual(shared_prefix(args), 'hi')
-
-
-class OrderedSetTest(unittest.TestCase):
-    def test_order(self):
-        oset = OrderedSet()
-        oset.push('1')
-        oset.push('1')
-        oset.push('2')
-        oset.push('1')
-        self.assertEqual(oset, ['2', '1'])

--- a/kademlia/utils.py
+++ b/kademlia/utils.py
@@ -18,22 +18,6 @@ def digest(string):
     return hashlib.sha1(string).digest()
 
 
-class OrderedSet(list):
-    """
-    Acts like a list in all ways, except in the behavior of the
-    :meth:`push` method.
-    """
-
-    def push(self, thing):
-        """
-        1. If the item exists in the list, it's removed
-        2. The item is pushed to the end of the list
-        """
-        if thing in self:
-            self.remove(thing)
-        self.append(thing)
-
-
 def shared_prefix(args):
     """
     Find the shared prefix between the strings.


### PR DESCRIPTION
### Issue
- `KBucket.remove_node` did not remove nodes in `replacement_nodes`.


Now `KBucket.remove_node` removes nodes in replacement_nodes. And `OrderedSet` has been removed because it is not used any more.