### PR TITLE
Support non-list iterables as arg to bootstrap

### DIFF
--- a/kademlia/network.py
+++ b/kademlia/network.py
@@ -117,9 +117,10 @@ class Server:
         Bootstrap the server by connecting to other known nodes in the network.
 
         Args:
-            addrs: A `list` of (ip, port) `tuple` pairs.  Note that only IP
+            addrs: An iterable of (ip, port) `tuple` pairs.  Note that only IP
                    addresses are acceptable - hostnames will cause an error.
         """
+        addrs = list(addrs)
         log.debug("Attempting to bootstrap node with %i initial contacts",
                   len(addrs))
         cos = list(map(self.bootstrap_node, addrs))


### PR DESCRIPTION
Previously a list was required. As the bootstrap function only takes one
parameter, one could provide it with a generator expression without needing
extra brackets e.g.:

This:
```
    node.bootstrap((x, 5678) for x in addrs)
```
instead of:
```
    node.bootstrap([(x, 5678) for x in addrs])
```