### PR TITLE
bug:the call __init__ failed

### DIFF
--- a/kademlia/network.py
+++ b/kademlia/network.py
@@ -220,7 +220,8 @@ class Server:
         log.info("Loading state from %s", fname)
         with open(fname, 'rb') as file:
             data = pickle.load(file)
-        svr = Server(data['ksize'], data['alpha'], data['id'])
+        svr = eval(cls.__name__+"(data['ksize'], data['alpha'], data['id'])")
+
         await svr.listen(port, interface)
         if data['neighbors']:
             await svr.bootstrap(data['neighbors'])


### PR DESCRIPTION
bug:Calling a load_state method after inheriting the kademlia.network.Server class causes the inherited and modified __init__ function to fail to act on the return value of the load_state method
fixed:Get the inherited class name and call the constructor via eval().